### PR TITLE
Fix argment handling and quoting.

### DIFF
--- a/bin/git-multi
+++ b/bin/git-multi
@@ -5,15 +5,18 @@ if [ ! -n "$1" ]; then
     exit 1
 fi
 
-case "$1" in
+command=$1
+shift
+
+case "$command" in
     add*)
-        git-multi-add "$2" "$3"
+        git-multi-add "$@"
     ;;
     work*)
-        git-multi-work "$2"
+        git-multi-work "$@"
     ;;
     run*)
-        git-multi-run "$2" "$3"
+        git-multi-run "$@"
     ;;
     *)
         echo "Pass the multi command."

--- a/bin/git-multi-add
+++ b/bin/git-multi-add
@@ -22,4 +22,4 @@ git config -f ".git-multi/${1}/config" core.worktree "../../"
 mkdir -p ".git-multi/${1}/info"
 echo ".git-multi/" >> .git-multi/${1}/info/exclude
 
-git multi run "${1}" "git checkout"
+git multi run "${1}" git checkout

--- a/bin/git-multi-run
+++ b/bin/git-multi-run
@@ -5,11 +5,14 @@ if [ ! -n "$1" ]; then
     exit 1;
 fi
 
+name=$1
+shift
+
 MPWD=`pwd`;
-echo ".git-multi" > "${MPWD}/.git-multi/${1}/info/exclude";
-for i in `ls .git-multi/ | grep -v "${1}"`;
+echo ".git-multi" > "${MPWD}/.git-multi/${name}/info/exclude";
+for i in `ls .git-multi/ | grep -v "${name}"`;
 do
-    GIT_WORK_TREE="$MPWD" GIT_DIR="${MPWD}/.git-multi/${i}" git ls-files >> "${MPWD}/.git-multi/${1}/info/exclude";
+    GIT_WORK_TREE="$MPWD" GIT_DIR="${MPWD}/.git-multi/${i}" git ls-files >> "${MPWD}/.git-multi/${name}/info/exclude";
 done
 
-GIT_WORK_TREE="$MPWD" GIT_DIR="${MPWD}/.git-multi/${1}" "$2";
+GIT_WORK_TREE="$MPWD" GIT_DIR="${MPWD}/.git-multi/${name}" "$@";


### PR DESCRIPTION
`git multi add` failed with `git-multi-run: line 15: git checkout: command not found`.
